### PR TITLE
fix load semantic.min.css error

### DIFF
--- a/built_in_directives/app/index.html
+++ b/built_in_directives/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>ng-book 2 - Built-in Directives with Angular 2</title>
 
-    <link href="/app/css/vendor/semantic.min.css" rel="stylesheet">
     {% for (var css in o.htmlWebpackPlugin.files.css) { %}
       <link href="{%=o.htmlWebpackPlugin.files.css[css] %}" rel="stylesheet">
     {% } %}

--- a/built_in_directives/webpack.config.js
+++ b/built_in_directives/webpack.config.js
@@ -113,7 +113,7 @@ function makeConfig(options) {
       loaders: [
         { test: /\.(png|jpg|gif|ico)$/,   loader: "file-loader?limit=0&name=[path][name].[ext]" },
         { test: /\.json$/, loader: 'json' },
-        { test: /^(?!.*\.min\.css$).*\.css$/, loader: ExtractTextPlugin.extract("style-loader", "css-loader?sourceMap")},
+        { test: /\.css$/, loader: ExtractTextPlugin.extract("style-loader", "css-loader?sourceMap")},
         { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,         loader: "url-loader" },
         { test: /\.html$/,    loader: "raw" },
         { test: /^index\.html$/, loader: "file-loader?name=[path][name].[ext]" },


### PR DESCRIPTION
Hello, in chapter floder "built_in_directives", webpack run error, because:
1. Css resolve loader excludes semantic.min.css;
2. The index.html stylesheet link src is worng when run at webpack-dev-server.
It's no need to refer this css at html, it has been require('../css/vendor/semantic.min.css') at app/ts/assets.ts;

I fixed them and please check.
